### PR TITLE
Update fail.js

### DIFF
--- a/lib/grunt/fail.js
+++ b/lib/grunt/fail.js
@@ -41,6 +41,18 @@ function dumpStack(e) {
   }
 }
 
+
+function getFailureString() {
+  var zeroFill = function(stringToFill) {
+    return ("0" + stringToFill).slice(-2);
+  };
+  var date = new Date(),
+      hour = zeroFill(date.getHours()),
+      min  = zeroFill(date.getMinutes()),
+      sec  = zeroFill(date.getSeconds());
+  return "last build failure at: " + hour + ":" + min + ":" + sec;
+}
+
 // A fatal error occurred. Abort immediately.
 fail.fatal = function(e, errcode) {
   writeln(e, 'fatal');
@@ -61,6 +73,7 @@ fail.warn = function(e, errcode) {
   if (!grunt.option('force')) {
     dumpStack(e);
     grunt.log.writeln().fail('Aborted due to warnings.');
+    grunt.log.writeln(getFailureString());
     grunt.util.exit(typeof errcode === 'number' ? errcode : fail.code.WARNING);
   }
 };


### PR DESCRIPTION
I'm not always looking at my terminal when grunt decides to go and do its thing. So when I see a failure message, I can't be completely sure which change killed it. Or when the build was last triggered.
Adding a "last failure" time stamp to the output helps a lot.
